### PR TITLE
Add Session.video column to the model

### DIFF
--- a/twospaces/conference/migrations/0005_add_video_to_session.py
+++ b/twospaces/conference/migrations/0005_add_video_to_session.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='session',
             name='conference',
-            field=models.ForeignKey(related_name='sessions', to='conference.Conference'),
+            field=models.ForeignKey(to='conference.Conference'),
         ),
         migrations.AlterField(
             model_name='session',

--- a/twospaces/conference/migrations/0005_add_video_to_session.py
+++ b/twospaces/conference/migrations/0005_add_video_to_session.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('conference', '0004_auto_20150429_1753'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='session',
+            name='conference',
+            field=models.ForeignKey(related_name='sessions', to='conference.Conference'),
+        ),
+        migrations.AlterField(
+            model_name='session',
+            name='video',
+            field=models.URLField(null=True, verbose_name=b'URL To Video', blank=True),
+        ),
+    ]

--- a/twospaces/conference/models.py
+++ b/twospaces/conference/models.py
@@ -190,7 +190,7 @@ SESSION_LEVELS = (
 
 class Session(models.Model):
   user = models.ForeignKey(settings.AUTH_USER_MODEL)
-  conference = models.ForeignKey(Conference, related_name='sessions')
+  conference = models.ForeignKey(Conference)
 
   room = models.ForeignKey(Room, blank=True, null=True)
   all_rooms = models.BooleanField(default=False)

--- a/twospaces/conference/models.py
+++ b/twospaces/conference/models.py
@@ -190,7 +190,7 @@ SESSION_LEVELS = (
 
 class Session(models.Model):
   user = models.ForeignKey(settings.AUTH_USER_MODEL)
-  conference = models.ForeignKey(Conference)
+  conference = models.ForeignKey(Conference, related_name='sessions')
 
   room = models.ForeignKey(Room, blank=True, null=True)
   all_rooms = models.BooleanField(default=False)
@@ -199,6 +199,7 @@ class Session(models.Model):
   name = models.CharField('Title of Talk', max_length=100)
   description = models.TextField()
   slides = models.URLField('URL To Presentation', blank=True, null=True)
+  video = models.URLField('URL To Video', blank=True, null=True)
 
   stype = models.CharField('Session Type', max_length=25, choices=SESSION_TYPES)
   level = models.CharField('Audience Level',

--- a/twospaces/conference/serializers.py
+++ b/twospaces/conference/serializers.py
@@ -14,7 +14,7 @@ class ProposedReadSizzler(DynamicFieldsMixin, serializers.ModelSerializer):
   class Meta:
     model = Session
     fields = ('id', 'user', 'name', 'description', 'level', 'stype', 'slides',
-              'start', 'duration')
+              'video', 'start', 'duration')
     read_only_fields = fields
 
 
@@ -22,7 +22,7 @@ class SessionSizzler(DynamicFieldsMixin, serializers.ModelSerializer):
 
   class Meta:
     model = Session
-    fields = ('name', 'description', 'level', 'stype', 'slides',
+    fields = ('name', 'description', 'level', 'stype', 'slides', 'video',
               'special_requirements')
 
 


### PR DESCRIPTION
I decided it'd be best to break up the work for pytexas/PyTexasWeb#23 into bite-sized chunks.

This first PR adds a `Session.video` column and associated migration and also adds the new column to a couple of the serializers.
